### PR TITLE
remove legacy lines from .sync.yml

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -1,8 +1,4 @@
 ---
-spec/spec_helper_acceptance.rb:
-  windows: true
-  dependencies:
-    - puppetlabs-stdlib
 spec/acceptance/nodesets/centos-511-x64.yml:
   unmanaged: true
 spec/acceptance/nodesets/centos-66-x64-pe.yml:


### PR DESCRIPTION
This is needed to make modulesync functional again
```
$ msync update -f windows_eventlog --message "modulesync 0.6.0" 
Syncing puppet-windows_eventlog
Cloning repository fresh
Cloning from git@github.com:voxpupuli/puppet-windows_eventlog.git
Creating new branch modulesync
Not managing spec/acceptance/nodesets/centos-511-x64.yml in puppet-windows_eventlog
Not managing spec/acceptance/nodesets/centos-66-x64-pe.yml in puppet-windows_eventlog
Not managing spec/acceptance/nodesets/centos-66-x64.yml in puppet-windows_eventlog
Not managing spec/acceptance/nodesets/centos-72-x64.yml in puppet-windows_eventlog
Not managing spec/acceptance/nodesets/debian-78-x64.yml in puppet-windows_eventlog
Not managing spec/acceptance/nodesets/debian-82-x64.yml in puppet-windows_eventlog
Not managing spec/acceptance/nodesets/ubuntu-server-1204-x64.yml in puppet-windows_eventlog
Not managing spec/acceptance/nodesets/ubuntu-server-1404-x64.yml in puppet-windows_eventlog
/home/bastelfreak/.gem/ruby/2.3.0/gems/modulesync-0.6.1/lib/modulesync/renderer.rb:14:in `read': No such file or directory @ rb_sysopen - ./moduleroot//spec/spec_helper_acceptance.rb (Errno::ENOENT)
	from /home/bastelfreak/.gem/ruby/2.3.0/gems/modulesync-0.6.1/lib/modulesync/renderer.rb:14:in `build'
	from /home/bastelfreak/.gem/ruby/2.3.0/gems/modulesync-0.6.1/lib/modulesync.rb:77:in `block (2 levels) in run'
	from /home/bastelfreak/.gem/ruby/2.3.0/gems/modulesync-0.6.1/lib/modulesync.rb:68:in `each'
	from /home/bastelfreak/.gem/ruby/2.3.0/gems/modulesync-0.6.1/lib/modulesync.rb:68:in `block in run'
	from /home/bastelfreak/.gem/ruby/2.3.0/gems/modulesync-0.6.1/lib/modulesync.rb:57:in `each'
	from /home/bastelfreak/.gem/ruby/2.3.0/gems/modulesync-0.6.1/lib/modulesync.rb:57:in `run'
	from /home/bastelfreak/.gem/ruby/2.3.0/gems/modulesync-0.6.1/bin/msync:8:in `<top (required)>'
	from /home/bastelfreak/.gem/ruby/2.3.0/bin/msync:23:in `load'
	from /home/bastelfreak/.gem/ruby/2.3.0/bin/msync:23:in `<main>'
```