### PR TITLE
Sync metadata.json license to be same as LICENSE (MIT)

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
   "name": "puppet-windows_eventlog",
   "version": "1.1.2-rc0",
   "author": "puppet",
-  "license": "Apache-2.0",
+  "license": "MIT",
   "summary": "Module for managing the windows event log",
   "source": "https://github.com/voxpupuli/puppet-windows_eventlog",
   "project_page": "https://github.com/voxpupuli/puppet-windows_eventlog",


### PR DESCRIPTION
LICENSE file is MIT but metadata.json has had Apache-2.0 for quite
some time