### PR TITLE
Set min version_requirement for Puppet + bump deps

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -21,11 +21,17 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 3.0.0 <5.0.0"
+      "version_requirement": ">= 4.6.0 < 5.0.0"
     },
     {
       "name": "puppetlabs/registry",
-      "version_requirement": ">= 1.0.0 <2.0.0"
+      "version_requirement": ">= 1.1.1 < 2.0.0"
+    }
+  ],
+  "requirements": [
+    {
+      "name": "puppet",
+      "version_requirement": ">= 3.8.7 < 5.0.0"
     }
   ]
 }


### PR DESCRIPTION
We currently only run automated tests against Puppet 3 latest and
therefore cannot guarantee that this module works as is expected with
earlier Puppet versions

Bump dependencies to the minimum version that should work under
Puppet 4, based on the metadata