### PR TITLE
Eliminate Warnings on Puppet 4+, allow registry module <4

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -54,10 +54,10 @@ define windows_eventlog (
     default => $log_path,
   }
 
-  validate_string($l_log_path)
-  validate_re($log_size, '^\d*$','The log_size argument must be a number or a string representation of a number')
-  validate_re($max_log_policy, '^(overwrite|manual|archive)$','The max_log_policy argument must contain overwrite, manual or archive')
-  validate_re($log_path_template, '%%NAME%%','The log_path_template must contain the string "%%NAME%%"')
+  validate_legacy(String, 'validate_string', $l_log_path)
+  validate_legacy(Optional[String], 'validate_re', $log_size, '^\d*$','The log_size argument must be a number or a string representation of a number')
+  validate_legacy(Optional[String], 'validate_re', $max_log_policy, '^(overwrite|manual|archive)$','The max_log_policy argument must contain overwrite, manual or archive')
+  validate_legacy(Optional[String], 'validate_re', $log_path_template, '%%NAME%%','The log_path_template must contain the string "%%NAME%%"')
 
   $root_key = 'HKLM\System\CurrentControlSet\Services\Eventlog'
 

--- a/metadata.json
+++ b/metadata.json
@@ -25,7 +25,7 @@
     },
     {
       "name": "puppetlabs/registry",
-      "version_requirement": ">= 1.1.1 < 3.0.0"
+      "version_requirement": ">= 1.1.1 < 4.0.0"
     }
   ],
   "requirements": [


### PR DESCRIPTION
#### Pull Request (PR) description
Eliminate Warnings on Puppet 4+, allow registry module <4

#### This Pull Request (PR) fixes the following issues
Fixes #60
Fixes stdlib deprecation messages.

