### PR TITLE
Manage registry values for all cases

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -78,9 +78,9 @@ define windows_eventlog (
   }
 
   $retention = $max_log_policy ? {
-    overwrite => '0',
-    manual    => '1',
-    archive   => '-1',
+    'overwrite' => '0',
+    'manual'    => '1',
+    'archive'   => '-1',
   }
 
   registry_value { "${root_key}\\${name}\\Retention":
@@ -90,9 +90,9 @@ define windows_eventlog (
   }
 
   $auto_backup_log_files = $max_log_policy ? {
-    overwrite => '0',
-    manual    => '0',
-    archive   => '-1',
+    'overwrite' => '0',
+    'manual'    => '0',
+    'archive'   => '-1',
   }
 
   registry_value { "${root_key}\\${name}\\AutoBackupLogFiles":

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -77,43 +77,27 @@ define windows_eventlog (
     data   => $log_size,
   }
 
-  case $max_log_policy {
-    'overwrite': {
-      registry_value { "${root_key}\\${name}\\Retention":
-        ensure => present,
-        type   => 'dword',
-        data   => '0',
-      }
-      registry_value { "${root_key}\\${name}\\AutoBackupLogFiles":
-        ensure => present,
-        type   => 'dword',
-        data   => '0',
-      }
-    }
-    'manual': {
-      registry_value { "${root_key}\\${name}\\Retention":
-        ensure => present,
-        type   => 'dword',
-        data   => '1',
-      }
-      registry_value { "${root_key}\\${name}\\AutoBackupLogFiles":
-        ensure => present,
-        type   => 'dword',
-        data   => '0',
-      }
-    }
-    'archive': {
-      registry_value { "${root_key}\\${name}\\Retention":
-        ensure => present,
-        type   => 'dword',
-        data   => '-1',
-      }
-      registry_value { "${root_key}\\${name}\\AutoBackupLogFiles":
-        ensure => present,
-        type   => 'dword',
-        data   => '-1',
-      }
-    }
-    default: {}
+  $retention = $max_log_policy ? {
+    overwrite => '0',
+    manual    => '1',
+    archive   => '-1',
+  }
+
+  registry_value { "${root_key}\\${name}\\Retention":
+    ensure => present,
+    type   => 'dword',
+    data   => $retention,
+  }
+
+  $auto_backup_log_files = $max_log_policy ? {
+    overwrite => '0',
+    manual    => '0',
+    archive   => '-1',
+  }
+
+  registry_value { "${root_key}\\${name}\\AutoBackupLogFiles":
+    ensure => present,
+    type   => 'dword',
+    data   => $auto_backup_log_files,
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -84,6 +84,11 @@ define windows_eventlog (
         type   => 'dword',
         data   => '0',
       }
+      registry_value { "${root_key}\\${name}\\AutoBackupLogFiles":
+        ensure => present,
+        type   => 'dword',
+        data   => '0',
+      }
     }
     'manual': {
       registry_value { "${root_key}\\${name}\\Retention":
@@ -91,8 +96,18 @@ define windows_eventlog (
         type   => 'dword',
         data   => '1',
       }
+      registry_value { "${root_key}\\${name}\\AutoBackupLogFiles":
+        ensure => present,
+        type   => 'dword',
+        data   => '0',
+      }
     }
     'archive': {
+      registry_value { "${root_key}\\${name}\\Retention":
+        ensure => present,
+        type   => 'dword',
+        data   => '-1',
+      }
       registry_value { "${root_key}\\${name}\\AutoBackupLogFiles":
         ensure => present,
         type   => 'dword',


### PR DESCRIPTION
All registry values should have values set in all cases,
to ensure when switching between them there is a consistent experience.

#### Pull Request (PR) description
I think the following changes will resolve the issue described in issue 65.
I'm not sure where else I would need to add tests or other changes to the module.
I used the documentation [here](https://docs.microsoft.com/en-us/windows/win32/eventlog/eventlog-key) to set the values chosen

#### This Pull Request (PR) fixes the following issues
Fixes #65 
